### PR TITLE
Bump Aeson upper bound

### DIFF
--- a/eventstore.cabal
+++ b/eventstore.cabal
@@ -80,7 +80,7 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base       >=4.7      && <5
-                     , aeson      >=0.8      && <0.9
+                     , aeson      >=0.8      && <0.10
                      , async      >=2.0      && <2.1
                      , bytestring >=0.10.4   && <0.11
                      , cereal     >=0.4      && <0.5


### PR DESCRIPTION
Seems to work fine and 0.9 makes EventStore work in Nix.