### PR TITLE
Fix `TimeSpan` bugs, expose more `TimeSpan` and `withBinary*` functions

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,12 @@
+0.10.0.0
+--------
+* Fix $maxAge and $cacheControl TimeSpan metadata serialization.
+* Fix `timeSpanFrom*` functions.
+* Implement `timeSpanTotalDays`, `timeSpanTotalHours`, `timeSpanTotalMinutes` and `timeSpanTotalSeconds`.
+* Add `withBinary` and `withBinaryAndMetadata`.
+* Remove useless `TimeSpan` `ToJSON` and `FromJSON` instances.
+* Drop `attoparsec` dependency.
+
 0.9.1.3
 -------
 * Increase cereal upper bound to <0.6

--- a/Database/EventStore.hs
+++ b/Database/EventStore.hs
@@ -34,6 +34,8 @@ module Database.EventStore
     , createEvent
     , withJson
     , withJsonAndMetadata
+    , withBinary
+    , withBinaryAndMetadata
      -- * Read Operations
     , StreamMetadataResult(..)
     , readEvent
@@ -96,6 +98,10 @@ module Database.EventStore
     , timeSpanFromMinutes
     , timeSpanFromHours
     , timeSpanFromDays
+    , timeSpanTotalDays
+    , timeSpanTotalHours
+    , timeSpanTotalMinutes
+    , timeSpanTotalSeconds
     , timeSpanTotalMillis
       -- * Transaction
     , Transaction

--- a/Database/EventStore/Internal/Manager/Subscription/Message.hs
+++ b/Database/EventStore/Internal/Manager/Subscription/Message.hs
@@ -132,14 +132,22 @@ _createPersistentSubscription group stream sett =
     , cpsStreamId          = putField stream
     , cpsResolveLinkTos    = putField $ psSettingsResolveLinkTos sett
     , cpsStartFrom         = putField $ psSettingsStartFrom sett
-    , cpsMsgTimeout        = putField $ ms $ psSettingsMsgTimeout sett
+    , cpsMsgTimeout        = putField
+                             . fromIntegral
+                             . (truncate :: Double -> Int64)
+                             . timeSpanTotalMillis
+                             $ psSettingsMsgTimeout sett
     , cpsRecordStats       = putField $ psSettingsExtraStats sett
     , cpsLiveBufSize       = putField $ psSettingsLiveBufSize sett
     , cpsReadBatchSize     = putField $ psSettingsReadBatchSize sett
     , cpsBufSize           = putField $ psSettingsHistoryBufSize sett
     , cpsMaxRetryCount     = putField $ psSettingsMaxRetryCount sett
     , cpsPreferRoundRobin  = putField False
-    , cpsChkPtAfterTime    = putField $ ms $ psSettingsCheckPointAfter sett
+    , cpsChkPtAfterTime    = putField
+                             . fromIntegral
+                             . (truncate :: Double -> Int64)
+                             . timeSpanTotalMillis
+                             $ psSettingsCheckPointAfter sett
     , cpsChkPtMaxCount     = putField $ psSettingsMaxCheckPointCount sett
     , cpsChkPtMinCount     = putField $ psSettingsMinCheckPointCount sett
     , cpsSubMaxCount       = putField $ psSettingsMaxSubsCount sett
@@ -147,7 +155,6 @@ _createPersistentSubscription group stream sett =
     }
   where
     strText = strategyText $ psSettingsNamedConsumerStrategy sett
-    ms      = fromIntegral . timeSpanTotalMillis
 
 --------------------------------------------------------------------------------
 instance Encode CreatePersistentSubscription
@@ -246,14 +253,22 @@ _updatePersistentSubscription group stream sett =
     , upsStreamId          = putField stream
     , upsResolveLinkTos    = putField $ psSettingsResolveLinkTos sett
     , upsStartFrom         = putField $ psSettingsStartFrom sett
-    , upsMsgTimeout        = putField $ ms $ psSettingsMsgTimeout sett
+    , upsMsgTimeout        = putField
+                             . fromIntegral
+                             . (truncate :: Double -> Int64)
+                             . timeSpanTotalMillis
+                             $ psSettingsMsgTimeout sett
     , upsRecordStats       = putField $ psSettingsExtraStats sett
     , upsLiveBufSize       = putField $ psSettingsLiveBufSize sett
     , upsReadBatchSize     = putField $ psSettingsReadBatchSize sett
     , upsBufSize           = putField $ psSettingsHistoryBufSize sett
     , upsMaxRetryCount     = putField $ psSettingsMaxRetryCount sett
     , upsPreferRoundRobin  = putField False
-    , upsChkPtAfterTime    = putField $ ms $ psSettingsCheckPointAfter sett
+    , upsChkPtAfterTime    = putField
+                             . fromIntegral
+                             . (truncate :: Double -> Int64)
+                             . timeSpanTotalMillis
+                             $ psSettingsCheckPointAfter sett
     , upsChkPtMaxCount     = putField $ psSettingsMaxCheckPointCount sett
     , upsChkPtMinCount     = putField $ psSettingsMinCheckPointCount sett
     , upsSubMaxCount       = putField $ psSettingsMaxSubsCount sett
@@ -261,7 +276,6 @@ _updatePersistentSubscription group stream sett =
     }
   where
     strText = strategyText $ psSettingsNamedConsumerStrategy sett
-    ms      = fromIntegral . timeSpanTotalMillis
 
 --------------------------------------------------------------------------------
 instance Encode UpdatePersistentSubscription

--- a/eventstore.cabal
+++ b/eventstore.cabal
@@ -10,7 +10,7 @@ name:                eventstore
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.9.1.3
+version:             0.10.0.0
 
 tested-with: GHC >= 7.8.3 && < 7.11
 
@@ -113,7 +113,6 @@ library
                      , uuid       ==1.3.*
                      , unordered-containers
                      , stm
-                     , attoparsec
 
   -- Directories containing source files.
   -- hs-source-dirs:


### PR DESCRIPTION
* Fix $maxAge and $cacheControl TimeSpan metadata serialization.
* Fix `timeSpanFrom*` functions.
* Implement `timeSpanTotalDays`, `timeSpanTotalHours`, `timeSpanTotalMinutes` and `timeSpanTotalSeconds`.
* Add `withBinary` and `withBinaryAndMetadata`.