### PR TITLE
adding extraneous cast to compile with GHCJS

### DIFF
--- a/Database/EventStore/Internal/Types.hs
+++ b/Database/EventStore/Internal/Types.hs
@@ -339,8 +339,10 @@ recordedEventDataAsJson = A.decode . fromStrict . recordedEventData
 
 --------------------------------------------------------------------------------
 -- | Converts a raw 'Int64' into an 'UTCTime'
+-- fromIntegral should be a no-op in GHC and allow eventstore to compile w GHCJS
+-- GHCJS maps CTime to Int32 (cf PR https://github.com/YoEight/eventstore/pull/47)
 toUTC :: Int64 -> UTCTime
-toUTC = posixSecondsToUTCTime . (/1000) . realToFrac . CTime
+toUTC = posixSecondsToUTCTime . (/1000) . realToFrac . CTime . fromIntegral
 
 --------------------------------------------------------------------------------
 -- | Constructs a 'RecordedEvent' from an 'EventRecord'.


### PR DESCRIPTION
GHCJS maps replace CTime with HTYPE_TIME_T (https://github.com/ghcjs/ghcjs-boot/blob/master/boot/base/Foreign/C/Types.hs)  and maps this symbol to Int32 (https://github.com/ghcjs/ghcjs/blob/master/include/HsBaseConfig.h)

Adding a fromIntegral should get optimized away and allow ghcjs to compile eventstore

(otherwise some defer-type-errors would do if that just happens to be a dependency not actually used from GHCJS as it is in my case but that makes you loose any typecheck)

