### PR TITLE
Export msDiffTime & Re-export NominalDiffTime

### DIFF
--- a/Database/EventStore.hs
+++ b/Database/EventStore.hs
@@ -184,6 +184,7 @@ module Database.EventStore
     , emptyStreamVersion
     , exactEventVersion
     , streamExists
+    , msDiffTime
       -- * Re-export
     , waitAsync
     , (<>)

--- a/Database/EventStore.hs
+++ b/Database/EventStore.hs
@@ -191,12 +191,13 @@ module Database.EventStore
     , NonEmpty(..)
     , nonEmpty
     , TLSSettings
+    , NominalDiffTime
     ) where
 
 --------------------------------------------------------------------------------
 import Data.Int
 import Data.Maybe
-
+import Data.Time (NominalDiffTime)
 --------------------------------------------------------------------------------
 import ClassyPrelude hiding (Builder, group)
 import Data.List.NonEmpty(NonEmpty(..), nonEmpty)


### PR DESCRIPTION
Need msDiffTime & NominalDiffTime available to write custom connection settings (without importing external libraries & duplicating functions).