### PR TITLE
Export msDiffTime & Re-export NominalDiffTime

### DIFF
--- a/Database/EventStore.hs
+++ b/Database/EventStore.hs
@@ -184,17 +184,20 @@ module Database.EventStore
     , emptyStreamVersion
     , exactEventVersion
     , streamExists
+    , msDiffTime
       -- * Re-export
     , waitAsync
     , (<>)
     , NonEmpty(..)
     , nonEmpty
     , TLSSettings
+    , NominalDiffTime
     ) where
 
 --------------------------------------------------------------------------------
 import Data.Int
 import Data.Maybe
+import Data.Time (NominalDiffTime)
 
 --------------------------------------------------------------------------------
 import ClassyPrelude hiding (Builder, group)


### PR DESCRIPTION
Need msDiffTime & NominalDiffTime available to write custom connection settings (without importing external libraries & duplicating functions).