### PR TITLE
Fix connection state-machine in case of close-connection message.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,4 +1,11 @@
-1.4.0
+1.3.2
+-----
+* Bug fix: Driver could end in a situation where it receives a close-connection message during
+  Authentication/Identification phase. Close-connection message was wrongly ignored letting pending
+  operations unanwsered at call-site. If the user forced the result of an operation, it could have lead the
+  current thread to block indefinately. The client state-machine switched to a wrong state.
+
+1.3.1
 -----
 * Better encoding of streaming interface ReadError.
 * Expose more internal functions of the streaming interface.

--- a/eventstore.cabal
+++ b/eventstore.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1183167359a5b717d35d6bbd4ca75dcce93e5223d77d575319cd5fe83124a473
+-- hash: 171ce48c5ca32c8763beafe10906ae6d4b555cfc1b24872d3f56cef12b1d761d
 
 name:           eventstore
-version:        1.3.1
+version:        1.3.2
 synopsis:       EventStore TCP Client
 description:    EventStore TCP Client <https://eventstore.org>
 category:       Database

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: eventstore
-version: 1.3.1
+version: 1.3.2
 homepage: https://github.com/YoEight/eventstore
 tested-with: GHC >= 7.8 && <= 8.6
 synopsis: EventStore TCP Client


### PR DESCRIPTION
Bug fix: Driver could end in a situation where it receives a close-connection message during
Authentication/Identification phase. Close-connection message was wrongly ignored letting pending
operations unanwsered at call-site. If the user forced the result of an operation, it could have lead the
current thread to block indefinately. The client state-machine switched to a wrong state.